### PR TITLE
lnd: start instances with trace logging

### DIFF
--- a/lnd.py
+++ b/lnd.py
@@ -28,7 +28,7 @@ class LndD(TailableProc):
             '--rpcport={}'.format(self.rpc_port),
             '--bitcoin.active',
             '--datadir={}'.format(lightning_dir),
-            '--debuglevel=debug',
+            '--debuglevel=trace',
             '--bitcoin.rpcuser=rpcuser',
             '--bitcoin.rpcpass=rpcpass',
             '--configfile={}'.format(os.path.join(lightning_dir, 'lnd.conf')),


### PR DESCRIPTION
In this commit we modify the logging level of lnd to use trace logging
as this will allow us to more easily track down compatibility
divergences as this will log each wire message in a pretty-printed
format.

I'll be removing the full rpc command dump from the trace logging later 
today so we avoid logging _entire_ blocks. 