### PR TITLE
Increase timeout for gossip to settle

### DIFF
--- a/test.py
+++ b/test.py
@@ -233,8 +233,8 @@ def test_gossip(node_factory, bitcoind, impls):
 
     # Wait for gossip to settle
     for n in nodes:
-        wait_for(lambda: len(n.getnodes()) == 5, interval=1, timeout=60)
-        wait_for(lambda: len(n.getchannels()) == 8, interval=1, timeout=60)
+        wait_for(lambda: len(n.getnodes()) == 5, interval=1, timeout=120)
+        wait_for(lambda: len(n.getchannels()) == 8, interval=1, timeout=120)
 
     # Now connect the first node to the line graph and the second one to the first
     node1.connect('localhost', nodes[0].daemon.port, nodes[0].id())


### PR DESCRIPTION
Increase timeout for gossip to settle in the test environment(5 lightningds) for test_gossip.

All test_gossip tests are failed now.
The propagation of gossip in the test environment(5 lightningds) seems to be slower than before.
All are passed if the timeout is increased(60s -> 120s).

> ________________________________________________________ test_gossip[eclair_eclair] ________________________________________________________
>
> &nbsp;&nbsp;&nbsp;&nbsp;@pytest.mark.parametrize("impls", product(impls, repeat=2), ids=idfn)
> &nbsp;&nbsp;&nbsp;&nbsp;def test_gossip(node_factory, bitcoind, impls):
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;...
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;for n in nodes:
> \>           wait_for(lambda: len(n.getnodes()) == 5, interval=1, timeout=60)
>
> test.py:236:
> \_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
>
> &nbsp;&nbsp;&nbsp;&nbsp;def wait_for(success, timeout=30, interval=1):
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;start_time = time.time()
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;while not success() and time.time() < start_time + timeout:
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;time.sleep(interval)
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;if time.time() > start_time + timeout:
> \>           raise ValueError("Error waiting for {}", success)
> E           ValueError: ('Error waiting for {}', <function test_gossip.<locals>.<lambda> at 0x7f3eaa9a6c80>)
>
> test.py:111: ValueError
> 
