### PR TITLE
test_forwarded_payment failed

### DIFF
--- a/eclair.py
+++ b/eclair.py
@@ -208,6 +208,14 @@ class EclairNode(object):
         self.daemon.start()
         time.sleep(1)
 
+    def check_route(self, node_id, amount):
+        try:
+            r = self.rpc._call("findroute", [node_id])
+        except ValueError as e:
+            if (str(e).find("command failed: route not found") > 0):
+                return False
+            raise
+        return True
 
 class EclairRpc(object):
 

--- a/lightningd.py
+++ b/lightningd.py
@@ -173,3 +173,12 @@ class LightningNode(object):
         time.sleep(5)
         self.daemon.start()
         time.sleep(1)
+
+    def check_route(self, node_id, amount):
+        try:
+            r = self.rpc.getroute(node_id, amount, 1.0)
+        except ValueError as e:
+            if (str(e).find("Could not find a route") > 0):
+                return False
+            raise
+        return True

--- a/lnd.py
+++ b/lnd.py
@@ -205,6 +205,15 @@ class LndNode(object):
         self.daemon.start()
         self.rpc = LndRpc(self.daemon.rpc_port)
 
+    def check_route(self, node_id, amount):
+        try:
+            req = lnrpc.QueryRoutesRequest(pub_key=node_id, amt=int(amount/1000), num_routes=1)
+            r = self.rpc.stub.QueryRoutes(req)
+        except grpc._channel._Rendezvous as e:
+            if (str(e).find("unable to find a path to destination") > 0):
+                return False
+            raise
+        return True
 
 class LndRpc(object):
 

--- a/test.py
+++ b/test.py
@@ -342,7 +342,7 @@ def test_forwarded_payment(bitcoind, node_factory, impls):
     # Make sure we have a path
     ids = [n.info()['id'] for n in nodes]
     route = [(ids[i-1], ids[i]) for i in range(1, len(ids))]
-    wait_for(lambda: node_has_route(nodes[0], route))
+    wait_for(lambda: node_has_route(nodes[0], route), timeout=120)
     sync_blockheight(bitcoind, nodes)
 
     src = nodes[0]

--- a/test.py
+++ b/test.py
@@ -349,6 +349,10 @@ def test_forwarded_payment(bitcoind, node_factory, impls):
     dst = nodes[len(nodes)-1]
     amount = int(capacity / 10)
     req = dst.invoice(amount)
+
+    print("Waiting for a route to be found")
+    wait_for(lambda: src.check_route(dst.id(), amount), timeout=120)
+
     payment_key = src.send(req)
     dec = lndecode(req)
     assert(sha256(unhexlify(payment_key)).digest() == dec.paymenthash)


### PR DESCRIPTION
Following tests may fail now.

- test_forwarded_payment[eclair_eclair_lightning]
- test_forwarded_payment[eclair_lightning_lightning]
- test_forwarded_payment[lightning_eclair_eclair]
- test_forwarded_payment[lightning_eclair_lnd]
- test_forwarded_payment[lightning_lightning_eclair]
- test_forwarded_payment[lightning_lightning_lightning]
- test_forwarded_payment[lnd_eclair_eclair]
- test_forwarded_payment[lnd_eclair_lnd]
- test_forwarded_payment[lnd_lightning_lightning]

The propagation of gossip of lightningd and eclair seems to be slower than before.
All are passed if the timeout is increased(60s -> 120s).

```
_______________ test_forwarded_payment[eclair_eclair_lightning] ________________

bitcoind = <utils.BitcoinD object at 0x7f46853595f8>
node_factory = <test.NodeFactory object at 0x7f4686f90358>
impls = (<class 'eclair.EclairNode'>, <class 'eclair.EclairNode'>, <class 'lightningd.LightningNode'>)

    @pytest.mark.parametrize("impls", product(impls, repeat=3), ids=idfn)
    def test_forwarded_payment(bitcoind, node_factory, impls):
        num_nodes = len(impls)
        nodes = [node_factory.get_node(implementation=impls[i]) for i in range(3)]
        capacity = 10**7

        for i in range(num_nodes-1):
            nodes[i].connect('localhost', nodes[i+1].daemon.port, nodes[i+1].id())
            nodes[i].addfunds(bitcoind, 4 * capacity)

        for i in range(num_nodes-1):
            nodes[i].openchannel(nodes[i+1].id(), 'localhost', nodes[i+1].daemon.port, capacity)
            confirm_channel(bitcoind, nodes[i], nodes[i+1])

        bitcoind.rpc.generate(6)
        sync_blockheight(bitcoind, nodes)

        # Make sure we have a path
        ids = [n.info()['id'] for n in nodes]
        route = [(ids[i-1], ids[i]) for i in range(1, len(ids))]
>       wait_for(lambda: node_has_route(nodes[0], route))

test.py:345:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

success = <function test_forwarded_payment.<locals>.<lambda> at 0x7f4686f6cbf8>
timeout = 30, interval = 1

    def wait_for(success, timeout=30, interval=1):
        start_time = time.time()
        while not success() and time.time() < start_time + timeout:
            time.sleep(interval)
        if time.time() > start_time + timeout:
>           raise ValueError("Error waiting for {}", success)
E           ValueError: ('Error waiting for {}', <function test_forwarded_payment.<locals>.<lambda> at 0x7f4686f6cbf8>)
```