### PR TITLE
Workaround for a feerate mismatch between lightningd and eclair

### DIFF
--- a/lightningd.py
+++ b/lightningd.py
@@ -28,6 +28,7 @@ class LightningD(TailableProc):
 
             # The following are temporary workarounds
             '--cltv-final=8',
+            '--dev-override-fee-rates={0}/{0}/{0}'.format(12*1000),  # Fix fee in sat/kw
         ]
         self.cmd_line += [
             "--{}={}".format(k, v) for k, v in LIGHTNINGD_CONFIG.items()

--- a/test.py
+++ b/test.py
@@ -57,6 +57,17 @@ class NodeFactory(object):
             n.daemon.stop()
 
 
+def transact_and_mine(btc):
+    """ Generate some transactions and blocks.
+
+    To make bitcoind's `estimatesmartfee` succeeded.
+    """
+    addr = btc.rpc.getnewaddress()
+    for i in range(10):
+        for j in range(10):
+            txid = btc.rpc.sendtoaddress(addr, 0.5)
+        btc.rpc.generate(1)
+
 @pytest.fixture()
 def bitcoind():
     btc = BitcoinD(bitcoin_dir=os.path.join(TEST_DIR, "bitcoind"), rpcport=28332)
@@ -70,6 +81,7 @@ def bitcoind():
     elif w_info['balance'] < 1:
         logging.debug("Insufficient balance, generating 1 block")
         btc.rpc.generate(1)
+    transact_and_mine(btc)
 
     yield btc
 


### PR DESCRIPTION
Workaround for a feerate mismatch between `lightningd` and `eclair`

The following test will not fail if executed alone.

`py.test -v test.py -s -k 'test_forwarded_payment[lnd_lightning_eclair]'`

However, if all `test_forwarded_payment` tests are executed consecutively, the test will fail.

`py.test -v test.py -s -k 'test_forwarded_payment'`

```
=================================== FAILURES ===================================
_________________ test_forwarded_payment[lnd_lightning_eclair] _________________

bitcoind = <utils.BitcoinD object at 0x7f0ca6f03400>
node_factory = <test.NodeFactory object at 0x7f0ca175f5f8>
impls = (<class 'lnd.LndNode'>, <class 'lightningd.LightningNode'>, <class 'eclair.EclairNode'>)

    @pytest.mark.parametrize("impls", product(impls, repeat=3), ids=idfn)
    def test_forwarded_payment(bitcoind, node_factory, impls):
        num_nodes = len(impls)
        nodes = [node_factory.get_node(implementation=impls[i]) for i in range(3)]
        capacity = 10**7

        for i in range(num_nodes-1):
            nodes[i].connect('localhost', nodes[i+1].daemon.port, nodes[i+1].id())
            nodes[i].addfunds(bitcoind, 4 * capacity)

        for i in range(num_nodes-1):
>           nodes[i].openchannel(nodes[i+1].id(), 'localhost', nodes[i+1].daemon.port, capacity)

test.py:336:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lightningd.py:95: in openchannel
    return self.rpc.fundchannel(node_id, satoshis)
../.local/lib/python3.5/site-packages/lightning/lightning.py:323: in fundchannel
    return self.call("fundchannel", payload)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <lightning.lightning.LightningRpc object at 0x7f0ca1774b38>
method = 'fundchannel'
payload = {'id': '020eeb0bc9d837ed413472a55d2754c2bd813f36e049f995f9a8f9185a94207516', 'satoshi': 10000000}

    def call(self, method, payload=None):
        self.logger.debug("Calling %s with payload %r", method, payload)

        if payload is None:
            payload = {}
        # Filter out arguments that are None
        payload = {k: v for k, v in payload.items() if v is not None}

        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
        sock.connect(self.socket_path)
        self._writeobj(sock, {
            "method": method,
            "params": payload,
            "id": 0
        })
        resp = self._readobj(sock)
        sock.close()

        self.logger.debug("Received response for %s call: %r", method, resp)
        if "error" in resp:
            raise ValueError(
                "RPC call failed: {}, method: {}, payload: {}".format(
                    resp["error"],
                    method,
>                   payload
E                   ValueError: RPC call failed: {'message': 'received ERROR channel 1ab8a105916d589cbf68ef9fc8e6ec65e29188394a7eb90405ccda75107d6a71: local/remote feerates are too different: remoteFeeratePerKw=5002 localFeeratePerKw=45000', 'code': -1}, method: fundchannel, payload: {'satoshi': 10000000, 'id': '020eeb0bc9d837ed413472a55d2754c2bd813f36e049f995f9a8f9185a94207516'}

../.local/lib/python3.5/site-packages/lightning/lightning.py:70: ValueError
```

As a cause, all tests use the same blockchain, and when transactions are sufficiently accumulated and `estimatesmartfee` succeeds, a feerate mismatch occurs between `lightningd` and `eclair`.

The first commit generates some transactions and blocks at the beginning of each test so that `estimatesmartfee` always succeeds during the all of tests.
In this state, the above test will fail even if it is executed alone.
It is for stabilizing the reproducibility of the phenomenon.

Also in this state, many tests to pay to `eclair` from `lightningd` will be failed.
In this state, it is impossible to detect the test failure due to other causes, so once I take workaround with the second commit（This code was once deleted by commit a8da8ce7f6553c6567a3504d7189ac217d8e15af).

