### PR TITLE
eclair and lnd: save log

### DIFF
--- a/eclair.py
+++ b/eclair.py
@@ -104,6 +104,7 @@ class EclairD(TailableProc):
             p.kill()
         psutil.wait_procs(alive, timeout=3)
         self.thread.join()
+        super().save_log()
 
 
 class EclairNode(object):

--- a/lnd.py
+++ b/lnd.py
@@ -70,6 +70,7 @@ class LndD(TailableProc):
         if self.proc.poll() is None:
             self.proc.kill()
             self.proc.wait()
+        super().save_log()
 
 
 class LndNode(object):

--- a/utils.py
+++ b/utils.py
@@ -64,14 +64,17 @@ class TailableProc(object):
         self.thread.start()
         self.running = True
 
-    def stop(self):
-        self.proc.terminate()
-        self.proc.kill()
+    def save_log(self):
         if self.outputDir:
             logpath = os.path.join(self.outputDir, 'log.' + str(int(time.time())))
             with open(logpath, 'w') as f:
                 for l in self.logs:
                     f.write(l + '\n')
+
+    def stop(self):
+        self.proc.terminate()
+        self.proc.kill()
+        self.save_log()
 
     def tail(self):
         """Tail the stdout of the process and remember it.


### PR DESCRIPTION
Logs of `lnd` and `eclair` were not saved, so they were saved.