### PR TITLE
make: Fixed lnd's version file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ bin/lightningd: src/lightning
 	cp src/lightning/lightningd/lightningd src/lightning/lightningd/lightning_* bin
 
 bin/lnd: src/lnd
-	(cd src/lnd; git rev-parse HEAD) > src/lnd/version
+	(cd ${GOPATH}/src/github.com/lightningnetwork/lnd; git rev-parse HEAD) > src/lnd/version
 	go get -u github.com/golang/dep/cmd/dep
 	cd ${GOPATH}/src/github.com/lightningnetwork/lnd; ${GOPATH}/bin/dep ensure; go install . ./cmd/...
 	cp ${GOPATH}/bin/lnd ${GOPATH}/bin/lncli bin/


### PR DESCRIPTION
The version of  `lightning-integration` was written in` lnd`'s version file, so I fixed it.