### PR TITLE
Fix Eclair: use java in path, make README list correct filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In order for the tests to run you'll need to compile the various clients and mov
 Please refer to the various compilation instructions and make sure that the structure matches the following diagram:
 
     bin
-    ├── eclair-node.jar
+    ├── eclair.jar
     ├── lightningd
     ├── lnd
     └── ptarmd

--- a/eclair.py
+++ b/eclair.py
@@ -46,7 +46,7 @@ class EclairD(TailableProc):
         self.prefix = 'eclair'
 
         self.cmd_line = [
-            '/usr/lib/jvm/java-8-openjdk-amd64/bin/java',
+            'java',
             '-Declair.datadir={}'.format(lightning_dir),
             '-Dlogback.configurationFile={}'.format(os.path.join(lightning_dir, 'logback.xml')),
             '-jar',


### PR DESCRIPTION
Since we are already using bitcoind and bitcoin-cli from $PATH, I think it will work with more users by just using the default java instead of one with a hardcoded path.