### PR TITLE
ptarmd: Fix the `status` string of `getinfo` method

### DIFF
--- a/ptarmd.py
+++ b/ptarmd.py
@@ -137,7 +137,7 @@ class PtarmNode(object):
                     self_id,
                     remote_id, state
                 ))
-                return state == 'established'
+                return state == 'normal operation'
 
         self.logger.warning("Channel {} -> {} not found".format(
             self_id,


### PR DESCRIPTION
Follows ptarmd's change
`test_open_channel` was failing

see #44