### PR TITLE
reconnects: add test for reconnecting across a channel creation boundary

### DIFF
--- a/eclair.py
+++ b/eclair.py
@@ -214,6 +214,12 @@ class EclairNode(object):
         self.daemon.start()
         time.sleep(1)
 
+    def stop(self):
+        self.daemon.stop()
+
+    def start(self):
+        self.daemon.start()
+
     def check_route(self, node_id, amount):
         try:
             r = self.rpc._call("findroute", [node_id, amount])

--- a/lightningd.py
+++ b/lightningd.py
@@ -205,6 +205,12 @@ class LightningNode(object):
         self.daemon.start()
         time.sleep(1)
 
+    def stop(self):
+        self.daemon.stop()
+
+    def start(self):
+        self.daemon.start()
+
     def check_route(self, node_id, amount):
         try:
             r = self.rpc.getroute(node_id, amount, 1.0)

--- a/lnd.py
+++ b/lnd.py
@@ -206,6 +206,13 @@ class LndNode(object):
         self.daemon.start()
         self.rpc = LndRpc(self.daemon.rpc_port)
 
+    def stop(self):
+        self.daemon.stop()
+
+    def start(self):
+        self.daemon.start()
+        self.rpc = LndRpc(self.daemon.rpc_port)
+
     def check_route(self, node_id, amount):
         try:
             req = lnrpc.QueryRoutesRequest(pub_key=node_id, amt=int(amount/1000), num_routes=1)

--- a/ptarmd.py
+++ b/ptarmd.py
@@ -244,6 +244,12 @@ class PtarmNode(object):
         self.daemon.start()
         time.sleep(1)
 
+    def stop(self):
+        self.daemon.stop()
+
+    def start(self):
+        self.daemon.start()
+
     def check_route(self, node_id, amount):
         proc = subprocess.run([
             '{}/bin/routing'.format(os.getcwd()),


### PR DESCRIPTION
currently fails the lightning_lnd configuration as lnd sends
channel_announcement sigs before channel_reestablish msg