### PR TITLE
ptarmd: Do not specify external IP address

### DIFF
--- a/ptarmd.py
+++ b/ptarmd.py
@@ -19,7 +19,6 @@ class PtarmD(TailableProc):
             'bin/ptarmd',
             '-d', lightning_dir,
             '-p', str(port),
-            '-a' '1.1.1.1',  # public, but not owned by us, can't use gossip to connect
             '-c', '{}/bitcoin.conf'.format(bitcoin_dir),
             '--rpcport', str(port+1234),
         ]


### PR DESCRIPTION
@cdecker 
Thank you for fixing the issue of `ptarmigan` (e661a8d84c86d9b2023d106a117bf13a0c9bb68c).

This option is the external ip address notified by the `node_announcement`.
Some node fails trying to connect to this ip address when reconnecting.
It is better not to specify this.