### PR TITLE
Bitcoin core 18.0 compatibility

### DIFF
--- a/fixtures.py
+++ b/fixtures.py
@@ -96,13 +96,14 @@ def bitcoind(directory):
     btc.start()
     bch_info = btc.rpc.getblockchaininfo()
     w_info = btc.rpc.getwalletinfo()
+    addr = btc.rpc.getnewaddress()
     # Make sure we have segwit and some funds
     if bch_info['blocks'] < 120:
         logging.debug("SegWit not active, generating some more blocks")
-        btc.rpc.generate(120 - bch_info['blocks'])
+        btc.rpc.generatetoaddress(120 - bch_info['blocks'], addr)
     elif w_info['balance'] < 1:
         logging.debug("Insufficient balance, generating 1 block")
-        btc.rpc.generate(1)
+        btc.rpc.generatetoaddress(1, addr)
 
     # Mock `estimatesmartfee` to make c-lightning happy
     def mock_estimatesmartfee(r):

--- a/lightningd.py
+++ b/lightningd.py
@@ -105,11 +105,12 @@ class LightningNode(object):
 
     def addfunds(self, bitcoind, satoshis):
         addr = self.getaddress()
+        btc_addr = bitcoind.rpc.getnewaddress()
         txid = bitcoind.rpc.sendtoaddress(addr, float(satoshis) / 10**8)
         bitcoind.rpc.getrawtransaction(txid)
         while len(self.rpc.listfunds()['outputs']) == 0:
             time.sleep(1)
-            bitcoind.rpc.generate(1)
+            bitcoind.rpc.generatetoaddress(1, btc_addr)
 
     def ping(self):
         """ Simple liveness test to see if the node is up and running

--- a/lnd.py
+++ b/lnd.py
@@ -128,9 +128,10 @@ class LndNode(object):
     def addfunds(self, bitcoind, satoshis):
         req = lnrpc.NewAddressRequest(type=1)
         addr = self.rpc.stub.NewAddress(req).address
+        btc_addr = bitcoind.rpc.getnewaddress()
         bitcoind.rpc.sendtoaddress(addr, float(satoshis) / 10**8)
         self.daemon.wait_for_log("Inserting unconfirmed transaction")
-        bitcoind.rpc.generate(1)
+        bitcoind.rpc.generatetoaddress(1, btc_addr)
         self.daemon.wait_for_log("Marking unconfirmed transaction")
 
         # The above still doesn't mean the wallet balance is updated,

--- a/ptarmd.py
+++ b/ptarmd.py
@@ -109,7 +109,7 @@ class PtarmNode(object):
         )
 
         time.sleep(1)
-        bitcoind.rpc.generate(1)
+        bitcoind.rpc.generatetoaddress(1, addr)
 
     def ping(self):
         """ Simple liveness test to see if the node is up and running

--- a/utils.py
+++ b/utils.py
@@ -21,7 +21,6 @@ BITCOIND_CONFIG = collections.OrderedDict([
     ("rpcuser", "rpcuser"),
     ("rpcpassword", "rpcpass"),
     ("listen", 0),
-    ("deprecatedrpc", "generate")
 ])
 
 

--- a/utils.py
+++ b/utils.py
@@ -20,7 +20,8 @@ BITCOIND_CONFIG = collections.OrderedDict([
     ("deprecatedrpc", "signrawtransaction"),
     ("rpcuser", "rpcuser"),
     ("rpcpassword", "rpcpass"),
-    ("listen", 0)
+    ("listen", 0),
+    ("deprecatedrpc", "generate")
 ])
 
 


### PR DESCRIPTION
Refactoring `generate` to `generatetoaddress` to be compatible with Bitcoin Core 0.18.

I did toy with the idea of simply adding another 'deprecatedrpc' flag to the bitcoind config as it was simpler, but the RPC will be removed altogether in the next major release so it made sense to stay ahead of such breaking changes.