### PR TITLE
Dockerfile: Add libsodium-dev and python3-mako for clightning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
     libgmp-dev \
     libjansson-dev \
     libsecp256k1-dev \
+    libsodium-dev \
     libsqlite3-dev \
     libssl-dev \
     libtool \
@@ -33,9 +34,10 @@ RUN apt-get update \
     net-tools \
     openjdk-8-jdk \
     pkg-config \
-    python3-pip \
-    python3 \
     python \
+    python3 \
+    python3-mako \
+    python3-pip \
     zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
It seems the dockerfile was broken with recent changes in clightning.

Even if this seems like an improvement, I'm still getting an error, see https://github.com/cdecker/lightning-integration/issues/59



