### PR TITLE
WIP: Dont cache makefile cache downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,5 @@ ENV LANG C.UTF-8
 ENV TEST_DEBUG=0
 
 WORKDIR /root/lightning-integration
+COPY Makefile /root/lightning-integration/Makefile
 CMD ["make", "update", "clients", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,4 +93,10 @@ ENV TEST_DEBUG=0
 
 WORKDIR /root/lightning-integration
 COPY Makefile /root/lightning-integration/Makefile
+
+RUN make src/eclair bin/eclair.jar
+RUN make src/ptarmigan bin/ptarmd
+RUN make src/lightning bin/lightningd
+RUN make src/lnd bin/lnd
+
 CMD ["make", "update", "clients", "test"]

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ push:
 	git commit --quiet -m "Deploy to GitHub Pages";\
 	git push --force "git@github.com:cdecker/lightning-integration.git" master:gh-pages
 
+docker-build:
+	docker build --tag=lnintegration .
+docker-run: docker-build
+	docker run lnintegration
 builder:
 	docker build -t cdecker/lightning-integration:latest - <Dockerfile
 	docker push cdecker/lightning-integration:latest

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ src/lnd:
 
 src/ptarmigan:
 	git clone https://github.com/nayutaco/ptarmigan.git src/ptarmigan
-	cd src/ptarmigan
 
 update: src/eclair src/lightning src/lnd src/ptarmigan
 	rm src/eclair/version src/lightning/version src/lnd/version src/ptarmigan/version || true

--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ The following changes to the default configuration are used to ensure compatibil
 
  - lnd
    - `--bitcoin.defaultremotedelay=144` since c-lightning will not allow large `to_self_delay`s (see lightningnetwork/lnd#788 and ElementsProject/lightning#1110)
+
+## Run with docker
+
+To build things in a local docker container:
+
+	docker build --tag=lnintegration .
+
+or
+
+	make docker-build
+
+To run things in that local docker container:
+
+	docker run lnintegration
+
+or
+
+	make docker-run


### PR DESCRIPTION
If testing with docker, any local change to the makefile was being ignored, that implied a -50 penalty for any sanity checks when modifying the makefile.

Also caching builds doesn't necessarily prevent the last step from making sure it gets the latest versions, I think. There's not need to separate them to do so, ```RUN make update clients``` right before CMD should do kind of the same.
Except - as an example - a change in go, which is fast to build, should need to wait for all the slow downloads to be cached again to test them again, since they didn't change.  