### PR TITLE
eclair: replace mainnet bitcoind port in conf

### DIFF
--- a/eclair.py
+++ b/eclair.py
@@ -67,7 +67,7 @@ class EclairD(TailableProc):
             ('enabled = false // disabled by default for security reasons', 'enabled = true'),
             ('password = ""', 'password = "rpcpass"'),
             ('9735', str(port)),
-            ('18332', str(self.bitcoind.rpcport)),
+            ('8332', str(self.bitcoind.rpcport)),
             ('8080', str(self.rpc_port)),
             ('"test"', '"regtest"'),
             ('"foo"', '"rpcuser"'),


### PR DESCRIPTION
A prior version of eclair used port 18332 in their reference conf, but
as of https://github.com/ACINQ/eclair/pull/989 it now uses the mainnet
port. As a result, eclair could not connect to bitcoind's rpc interface
and caused a large number of test failures.