### PR TITLE
Docker: Don't clone this repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,21 +75,23 @@ RUN cd /tmp \
 
 ENV GOROOT=/usr/local/go
 
-# lightning-integration
-RUN git clone https://github.com/cdecker/lightning-integration.git /root/lightning-integration \
-  && ln -sf /usr/bin/python3 /usr/bin/python \
-  && ln -sf /usr/bin/pip3 /usr/bin/pip \
-  && pip install -r /root/lightning-integration/requirements.txt
-
 # eclair
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 VOLUME /root/lightning-integration/reports
 VOLUME /root/lightning-integration/output
 
+WORKDIR /root/lightning-integration
+
+# lightning-integration
+COPY requirements.txt /root/lightning-integration/requirements.txt
+RUN ln -sf /usr/bin/python3 /usr/bin/python \
+  && ln -sf /usr/bin/pip3 /usr/bin/pip \
+  && pip install -r /root/lightning-integration/requirements.txt
+
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 ENV TEST_DEBUG=0
 
-WORKDIR /root/lightning-integration
+COPY . /root/lightning-integration/
 CMD ["make", "update", "clients", "test"]


### PR DESCRIPTION
As discussed in https://github.com/cdecker/lightning-integration/pull/62#discussion_r306429218 , if you're testing this using the included Dockerfile (which is what I find most convenient personally), any changes made locally to makefile or any python file will be ignored as if nothing was done because the Dockerfile always uses the master of this repository instead of your local changes.

This fixes this.
The line ```COPY . /root/lightning-integration/``` is ugly and we could do better, but right now that would result in a lot of individual COPY lines in the Dockerfile. Perhaps we can avoid this in the future by restructuring directories differently. For example, moving all the python code to one directory to copy it at once in a single COPY.

This should also make the build slightly faster by avoiding one git clone.

Note: This seems to be "passing" the travis tests (ie seems it will fail by 50 min timeout) in https://github.com/jtimon/lightning-integration/pull/3