### PR TITLE
Makefile: Doc: how to run as a local docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,10 @@ push:
 	git commit --quiet -m "Deploy to GitHub Pages";\
 	git push --force "git@github.com:cdecker/lightning-integration.git" master:gh-pages
 
+docker-build:
+	docker build --tag=lnintegration .
+docker-run: docker-build
+	docker run lnintegration
 builder:
 	docker build -t cdecker/lightning-integration:latest - <Dockerfile
 	docker push cdecker/lightning-integration:latest

--- a/README.md
+++ b/README.md
@@ -57,3 +57,21 @@ The following changes to the default configuration are used to ensure compatibil
 
  - lnd
    - `--bitcoin.defaultremotedelay=144` since c-lightning will not allow large `to_self_delay`s (see lightningnetwork/lnd#788 and ElementsProject/lightning#1110)
+
+## Run with docker
+
+To build things in a local docker container:
+
+	docker build --tag=lnintegration .
+
+or
+
+	make docker-build
+
+To both build and run that local docker container:
+
+	docker build --tag=lnintegration . && docker run lnintegration
+
+or
+
+	make docker-run


### PR DESCRIPTION
Adds 2 new targets to the makefile that I personally find convenient and documents them in the readme.