### PR TITLE
Travis: Check the dockerfile builds at the very least

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: bash
+services: docker
+
+build:
+  - docker build -t lnintegration .
+
+after_success:
+  # Log that the build worked, because we all need some good news
+  - echo "Success running lightning-integration"


### PR DESCRIPTION
This is a very minimal introduction to travis.
It will only check that bujilding the dockerfile works, but that's better than nothing.

Ideally we would want to outsource running all the tests for every pr apart from running them locally, because why not. But travis has a reasonable limitation of 50 min per job.

I will try propose more ugly improvements to this in https://github.com/cdecker/lightning-integration/pull/66 , but I think this is a good simple start to build and discuss on top of.
I think we all want this to always work and is easy.