### PR TITLE
Makefile: Make eclair and lightningd builds parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,28 @@
 language: bash
 services: docker
 
-build:
-  - docker build -t lnintegration .
+install:
+  - make docker-build
 
 after_success:
   # Log that the build worked, because we all need some good news
   - echo "Success running lightning-integration"
+
+jobs:
+  include:
+
+    - name: 'Build eclair'
+      script:
+        - docker run lnintegration bash -c "make update-eclair bin/eclair.jar && py.test -v test.py -k EclairNode"
+
+    - name: 'Build clightning'
+      script:
+        - docker run lnintegration bash -c "make update-clightning bin/lightningd && py.test -v test.py -k LightningNode"
+
+    - name: 'Build lnd'
+      script:
+        - docker run lnintegration bash -c "make update-lnd bin/lnd && py.test -v test.py -k LndNode"
+
+    - name: 'Build ptarmigan'
+      script:
+        - docker run lnintegration bash -c "make update-ptarmigan bin/ptarmd && py.test -v test.py -k PtarmNode"

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     libzmq3-dev \
     miniupnpc \
     net-tools \
-    openjdk-8-jdk \
+    openjdk-11-jdk \
     pkg-config \
     python \
     python3 \
@@ -59,6 +59,7 @@ RUN cd /tmp \
     && cp bitcoin-$BITCOIN_VERSION/bin/bitcoin* /usr/bin/ \
     && rm -rf $BITCOIN_TARBALL bitcoin-$BITCOIN_VERSION
 
+# maven for java builds (eclair)
 RUN cd /tmp \
     && wget -qO mvn.tar.gz https://www-us.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz \
     && tar -xzf mvn.tar.gz \
@@ -74,9 +75,6 @@ RUN cd /tmp \
     && ln -s /usr/local/go/bin/go /usr/bin/
 
 ENV GOROOT=/usr/local/go
-
-# eclair
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 
 VOLUME /root/lightning-integration/reports
 VOLUME /root/lightning-integration/output

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,23 @@ src/lnd:
 src/ptarmigan:
 	git clone https://github.com/nayutaco/ptarmigan.git src/ptarmigan
 
-update: src/eclair src/lightning src/lnd src/ptarmigan
-	rm src/eclair/version src/lightning/version src/lnd/version src/ptarmigan/version || true
-
+update-eclair: src/eclair
+	rm src/eclair/version || true
 	cd src/eclair && git stash; git pull origin master
+
+update-clightning: src/lightning
+	rm src/lightning/version || true
 	cd src/lightning && git stash; git pull origin master
+
+update-lnd: src/lnd
+	rm src/lnd/version || true
 	cd src/lnd && git stash; git pull origin master
+
+update-ptarmigan: src/ptarmigan
+	rm src/ptarmigan/version || true
 	cd src/ptarmigan && git stash; git pull origin master
+
+update: update-eclair update-clightning update-lnd update-ptarmigan
 
 bin/eclair.jar: src/eclair
 	(cd src/eclair; git rev-parse HEAD) > src/eclair/version


### PR DESCRIPTION
It doesn't seem to work for ptarmd.
I didn't do anything for lnd since it is pretty fast, but it may be doing it on its own: it seems to be using multiple cores.

Of course, no problem on changing the default 4 to something else.

Dependencies:

- [x] Docker: Eclair: Upgrade openjdk from 8 to 11 #79
- [x] Travis: build clients independently https://github.com/cdecker/lightning-integration/pull/77
