### PR TITLE
ERROR: Travis job for building all clients at once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,7 @@ jobs:
     - name: 'Build ptarmigan'
       script:
         - docker run lnintegration bash -c "make update-ptarmigan bin/ptarmd && py.test -v test.py -k PtarmNode"
+
+    - name: 'Build all clients'
+      script:
+        - docker run lnintegration bash -c "make update clients"


### PR DESCRIPTION
Try to build all clients at once in a job.
Perhaps building the clients doesn't timeout travis and it was the tests, or the java upgrade fixed it. 

Dependencies:

- [x] Docker: Eclair: Upgrade openjdk from 8 to 11 #79
- [x] Travis: build clients independently https://github.com/cdecker/lightning-integration/pull/77
