### PR TITLE
Docker: clightning: Add new gettext dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,10 +61,10 @@ RUN cd /tmp \
 
 # maven for java builds (eclair)
 RUN cd /tmp \
-    && wget -qO mvn.tar.gz https://www-us.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz \
+    && wget -qO mvn.tar.gz https://www-us.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.tar.gz \
     && tar -xzf mvn.tar.gz \
     && rm mvn.tar.gz \
-    && mv apache-maven-3.6.0 /usr/local/maven \
+    && mv apache-maven-3.6.2 /usr/local/maven \
     && ln -s /usr/local/maven/bin/mvn /usr/local/bin
 
 RUN cd /tmp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     build-essential \
     clang \
     curl \
+    gettext \
     git \
     jq \
     libboost-all-dev \

--- a/lightningd.py
+++ b/lightningd.py
@@ -26,7 +26,6 @@ class LightningD(TailableProc):
             '--bitcoin-datadir={}'.format(self.bitcoind.bitcoin_dir),
             '--lightning-dir={}'.format(lightning_dir),
             '--addr=127.0.0.1:{}'.format(port),
-            '--dev-broadcast-interval=500',
             '--dev-bitcoind-poll=1',
             '--plugin-dir=src/lightning/plugins',
 


### PR DESCRIPTION
...and upgrade maven to 3.6.2 (3.6.0 is no longer available for download).

Also, remove deprecated --dev-broadcast-interval option in clightning.